### PR TITLE
Don't load fts in pythonpkg/duckdb_extension_config.cmake

### DIFF
--- a/tools/pythonpkg/duckdb_extension_config.cmake
+++ b/tools/pythonpkg/duckdb_extension_config.cmake
@@ -7,7 +7,6 @@
 # CMakeLists.txt file with the `BUILD_PYTHON` variable.
 # TODO: unify this by making setup.py also use this configuration, making this the config for all python builds
 duckdb_extension_load(json)
-duckdb_extension_load(fts)
 duckdb_extension_load(tpcds)
 duckdb_extension_load(tpch)
 duckdb_extension_load(parquet)


### PR DESCRIPTION
The FTS extension has been moved out-of-tree in #14872.
When building DuckDB with `BUILD_PYTHON=1`, the extension will not be found anymore at the old location _extension/fts_ and CMake will throw an error:

> CMake Error at CMakeLists.txt:1280 (add_subdirectory):
  add_subdirectory given source "~/duckdb/extension/fts" which is not an existing directory.

The error occurs because `duckdb_extension_load(fts)` is still called in the Python extension config. To fix the error, I removed this call.
(Alternatively, if the FTS extension should still be built together with the Python package, one could set the source path to the out-of-tree directory. But this has not been done for any out-of-tree extension, so I assume it will not be the case for FTS either.)